### PR TITLE
Add `checkbox` slot support

### DIFF
--- a/src/lib/components/Tree.vue
+++ b/src/lib/components/Tree.vue
@@ -16,6 +16,13 @@
         @emitOnUpdated="onDataUpdated"
         @emitCheckboxToggle="onCheckboxToggle"
       >
+        <template #checkbox="{ toggleCheckbox, checked }">
+          <slot
+            name="checkbox"
+            :checked="checked"
+            :toggleCheckbox="toggleCheckbox"
+          />
+        </template>
         <template v-if="useIcon" #iconActive>
           <slot name="iconActive"></slot>
         </template>

--- a/src/lib/components/TreeRow.vue
+++ b/src/lib/components/TreeRow.vue
@@ -21,6 +21,11 @@
           </slot>
         </template>
       </template>
+      <slot
+        name="checkbox" 
+        :checked="reactiveNode.checked" 
+        :toggleCheckbox="($event) => { this.toggleCheckbox(reactiveNode, $event)}"
+      />
       <input
         v-if="useCheckbox"
         type="checkbox"
@@ -62,6 +67,13 @@
             <arrow-down />
           </slot>
         </template>
+        <template #checkbox>
+          <slot
+            name="checkbox" 
+            :checked="child.checked" 
+            :toggleCheckbox="($event) => { this.toggleCheckbox(child, $event) }"
+          />
+      </template>
       </tree-row>
     </ul>
   </li>
@@ -147,6 +159,7 @@ export default {
     })
 
     const toggleCheckbox = (node, event) => {
+      event.stopPropagation();
       reactiveNode.value.checked = !reactiveNode.value.checked
       nextTick(()=>{
         emit('emitCheckboxToggle', {

--- a/src/lib/components/TreeRow.vue
+++ b/src/lib/components/TreeRow.vue
@@ -24,7 +24,7 @@
       <slot
         name="checkbox" 
         :checked="reactiveNode.checked" 
-        :toggleCheckbox="($event) => { this.toggleCheckbox(reactiveNode, $event)}"
+        :toggleCheckbox="($event) => toggleCheckbox(reactiveNode, $event)"
       />
       <input
         v-if="useCheckbox"
@@ -71,7 +71,7 @@
           <slot
             name="checkbox" 
             :checked="child.checked" 
-            :toggleCheckbox="($event) => { this.toggleCheckbox(child, $event) }"
+            :toggleCheckbox="($event) => toggleCheckbox(child, $event)"
           />
       </template>
       </tree-row>


### PR DESCRIPTION
I added a support to be able to use the custom checkbox. Below is a usage example.

```vue
<template>
  <Tree :nodes="data">
    <template #checkbox="{ toggleCheckbox, checked }">
      <input
        type="checkbox" 
        :checked="checked"
        @click="toggleCheckbox" 
      />
    </template>
  </Tree>
</template>
```