### PR TITLE
Transfer indeterminate values of checkboxes to slot

### DIFF
--- a/src/lib/components/Tree.vue
+++ b/src/lib/components/Tree.vue
@@ -12,17 +12,17 @@
         :gap="gap"
         :expand-row-by-default="reactiveExpandRowByDefault"
         :row-hover-background="rowHoverBackground"
-        :indeterminate-status="isIndeterminate.status"
+        :indeterminate="isIndeterminate"
         @emitNodeExpanded="onNodeExpanded"
         @emitOnUpdated="onDataUpdated"
         @emitCheckboxToggle="onCheckboxToggle"
       >
-        <template #checkbox="{ toggleCheckbox, checked, indeterminateStatus }">
+        <template #checkbox="{ toggleCheckbox, checked, indeterminate }">
           <slot
             name="checkbox"
             :checked="checked"
             :toggleCheckbox="toggleCheckbox"
-            :indeterminateStatus="indeterminateStatus"
+            :indeterminate="indeterminate"
           ></slot>
         </template>
         <template v-if="useIcon" #iconActive>
@@ -100,7 +100,7 @@ export default {
     const { searchTree } = useSearch()
     const reactiveNodes = ref(props.nodes)
     const reactiveExpandRowByDefault = ref(props.expandRowByDefault)
-    const isIndeterminate = reactive({ status: false })
+    const isIndeterminate = ref( false )
     onMounted(() => {
       reactiveNodes.value = initData(reactiveNodes.value)
     })
@@ -157,7 +157,7 @@ export default {
 
         check = check != parent ? parent : 0
 
-        isIndeterminate.status = parent.indeterminate
+        isIndeterminate.value = !every && some
       }
       emit('onCheckboxToggle', context)
     }

--- a/src/lib/components/Tree.vue
+++ b/src/lib/components/Tree.vue
@@ -12,16 +12,18 @@
         :gap="gap"
         :expand-row-by-default="reactiveExpandRowByDefault"
         :row-hover-background="rowHoverBackground"
+        :indeterminate-status="isIndeterminate.status"
         @emitNodeExpanded="onNodeExpanded"
         @emitOnUpdated="onDataUpdated"
         @emitCheckboxToggle="onCheckboxToggle"
       >
-        <template #checkbox="{ toggleCheckbox, checked }">
+        <template #checkbox="{ toggleCheckbox, checked, indeterminateStatus }">
           <slot
             name="checkbox"
             :checked="checked"
             :toggleCheckbox="toggleCheckbox"
-          />
+            :indeterminateStatus="indeterminateStatus"
+          ></slot>
         </template>
         <template v-if="useIcon" #iconActive>
           <slot name="iconActive"></slot>
@@ -35,7 +37,7 @@
 </template>
 
 <script>
-import { ref, watch, onMounted } from 'vue'
+import { ref, watch, onMounted, reactive } from 'vue'
 import TreeRow from './TreeRow.vue'
 import initData from '../composables/initData'
 import useSearch from '../composables/useSearch'
@@ -98,7 +100,7 @@ export default {
     const { searchTree } = useSearch()
     const reactiveNodes = ref(props.nodes)
     const reactiveExpandRowByDefault = ref(props.expandRowByDefault)
-
+    const isIndeterminate = reactive({ status: false })
     onMounted(() => {
       reactiveNodes.value = initData(reactiveNodes.value)
     })
@@ -154,6 +156,8 @@ export default {
         parent.indeterminate = !every && every !== some
 
         check = check != parent ? parent : 0
+
+        isIndeterminate.status = parent.indeterminate
       }
       emit('onCheckboxToggle', context)
     }
@@ -168,6 +172,7 @@ export default {
       reactiveExpandRowByDefault,
       onCheckboxToggle,
       onDataUpdated,
+      isIndeterminate,
     }
   },
 }

--- a/src/lib/components/TreeRow.vue
+++ b/src/lib/components/TreeRow.vue
@@ -4,6 +4,7 @@
     :style="{'padding-left': depth * indentSize + 'px',
              'gap': gap + 'px',
              '--row-hover-background': rowHoverBackground}"
+    :indeterminate-status="indeterminateStatus"
   >
     <div
       class="tree-row-item"
@@ -22,10 +23,11 @@
         </template>
       </template>
       <slot
-        name="checkbox" 
-        :checked="reactiveNode.checked" 
+        name="checkbox"
+        :checked="reactiveNode.checked"
         :toggleCheckbox="($event) => toggleCheckbox(reactiveNode, $event)"
-      />
+        :indeterminateStatus="indeterminateStatus"
+      ></slot>
       <input
         v-if="useCheckbox"
         type="checkbox"
@@ -52,6 +54,7 @@
         :gap="gap"
         :expand-row-by-default="expandRowByDefault"
         :indent-size="indentSize"
+        :indeterminate-status="indeterminateStatus"
         :row-hover-background="rowHoverBackground"
         @emitNodeExpanded="emitNodeExpanded"
         @emitOnUpdated="emitOnUpdated"
@@ -69,11 +72,12 @@
         </template>
         <template #checkbox>
           <slot
-            name="checkbox" 
-            :checked="child.checked" 
+            name="checkbox"
+            :checked="child.checked"
             :toggleCheckbox="($event) => toggleCheckbox(child, $event)"
-          />
-      </template>
+            :indeterminateStatus="indeterminateStatus"
+          ></slot>
+        </template>
       </tree-row>
     </ul>
   </li>
@@ -122,6 +126,10 @@ export default {
       type: String,
       default: '#e0e0e0',
     },
+    indeterminateStatus: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ['emitNodeExpanded', 'emitCheckboxToggle', 'emitOnUpdated'],
   setup(props, { emit }) {
@@ -159,7 +167,7 @@ export default {
     })
 
     const toggleCheckbox = (node, event) => {
-      event.stopPropagation();
+      event.stopPropagation()
       reactiveNode.value.checked = !reactiveNode.value.checked
       nextTick(()=>{
         emit('emitCheckboxToggle', {

--- a/src/lib/components/TreeRow.vue
+++ b/src/lib/components/TreeRow.vue
@@ -4,7 +4,7 @@
     :style="{'padding-left': depth * indentSize + 'px',
              'gap': gap + 'px',
              '--row-hover-background': rowHoverBackground}"
-    :indeterminate-status="indeterminateStatus"
+    :indeterminate="indeterminate"
   >
     <div
       class="tree-row-item"
@@ -26,7 +26,7 @@
         name="checkbox"
         :checked="reactiveNode.checked"
         :toggleCheckbox="($event) => toggleCheckbox(reactiveNode, $event)"
-        :indeterminateStatus="indeterminateStatus"
+        :indeterminate="indeterminate"
       ></slot>
       <input
         v-if="useCheckbox"
@@ -54,7 +54,7 @@
         :gap="gap"
         :expand-row-by-default="expandRowByDefault"
         :indent-size="indentSize"
-        :indeterminate-status="indeterminateStatus"
+        :indeterminate="indeterminate"
         :row-hover-background="rowHoverBackground"
         @emitNodeExpanded="emitNodeExpanded"
         @emitOnUpdated="emitOnUpdated"
@@ -75,7 +75,7 @@
             name="checkbox"
             :checked="child.checked"
             :toggleCheckbox="($event) => toggleCheckbox(child, $event)"
-            :indeterminateStatus="indeterminateStatus"
+            :indeterminate="indeterminate"
           ></slot>
         </template>
       </tree-row>
@@ -126,7 +126,7 @@ export default {
       type: String,
       default: '#e0e0e0',
     },
-    indeterminateStatus: {
+    indeterminate: {
       type: Boolean,
       default: false,
     },


### PR DESCRIPTION
If we want to use the indeterminate feature on the slot, the example is as follows.
```vue
<template>
  <Tree :nodes="data">
    <template #checkbox="{ toggleCheckbox, checked, indeterminateStatus }">
      <input
        type="checkbox"
        :checked="checked"
        :indeterminateStatus="indeterminateStatus"
        @click="toggleCheckbox"
      >
    </template>
  </Tree>
</template>
```
closes #48
