### PR TITLE
Add item delete feature to vue3 tree

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,8 +28,8 @@ module.exports = {
     'vue/singleline-html-element-content-newline': 'off',
     'vue/html-self-closing': ['error', {
       html: {
-        void: 'never',
-        normal: 'never',
+        void: 'always',
+        normal: 'always',
         component: 'always',
       },
     }],

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script>
-import { ref } from 'vue'
-import Tree from './lib/index'
+import { ref } from 'vue';
+import Tree from './lib/index';
 
 export default {
   components: {
@@ -40,11 +40,11 @@ export default {
         id: 6,
         label: 'People',
       },
-    ])
+    ]);
 
     return {
       data,
-    }
+    };
   },
-}
+};
 </script>

--- a/src/lib/components/Icons/DeleteIcon.vue
+++ b/src/lib/components/Icons/DeleteIcon.vue
@@ -1,0 +1,27 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="feather feather-x"
+  >
+    <line
+      x1="18"
+      y1="6"
+      x2="6"
+      y2="18"
+    />
+    <line
+      x1="6"
+      y1="6"
+      x2="18"
+      y2="18"
+    />
+  </svg>
+</template>

--- a/src/lib/components/Tree.vue
+++ b/src/lib/components/Tree.vue
@@ -8,6 +8,7 @@
         :node="node"
         :use-checkbox="useCheckbox"
         :use-icon="useIcon"
+        :use-row-delete="useRowDelete"
         :indent-size="indentSize"
         :gap="gap"
         :expand-row-by-default="reactiveExpandRowByDefault"
@@ -16,6 +17,7 @@
         :get-node="getNode"
         :update-node="updateNode"
         :expandable="expandable"
+        @delete-row="onDeleteRow"
         @node-expanded="onNodeExpanded"
         @checkbox-toggle="onCheckboxToggle"
       >
@@ -33,6 +35,9 @@
         <template v-if="useIcon" #iconInactive>
           <slot name="iconInactive" />
         </template>
+        <template v-if="useRowDelete" #closeIcon>
+          <slot name="closeIcon" />
+        </template>
       </tree-row>
     </ul>
   </div>
@@ -43,7 +48,7 @@ import { ref, watch, reactive } from 'vue';
 import TreeRow from './TreeRow.vue';
 import initData from '../composables/initData';
 import useSearch from '../composables/useSearch';
-import { setNodeById, getNodeById, updateNodeById, updateNodes } from '../utils';
+import { setNodeById, getNodeById, updateNodeById, updateNodes, removeNodeById } from '../utils';
 
 export default {
   name: 'Tree',
@@ -91,6 +96,10 @@ export default {
     useIcon:{
       type: Boolean,
       default: true,
+    },
+    useRowDelete:{
+      type: Boolean,
+      default: false,
     },
     rowHoverBackground: {
       type: String,
@@ -154,6 +163,11 @@ export default {
       emit('update', state.data);
     };
 
+    const onDeleteRow = node => {
+      removeNodeById(state.data, node.id);
+      state.data = updateNodes(removeNodeById(state.data, node.id));
+    };
+
     return {
       setNode,
       getNode,
@@ -164,6 +178,7 @@ export default {
       onCheckboxToggle,
       onUpdate,
       toggleCheckbox,
+      onDeleteRow,
     };
   },
 };

--- a/src/lib/components/Tree.vue
+++ b/src/lib/components/Tree.vue
@@ -28,10 +28,10 @@
           />
         </template>
         <template v-if="useIcon" #iconActive>
-          <slot name="iconActive"></slot>
+          <slot name="iconActive" />
         </template>
         <template v-if="useIcon" #iconInactive>
-          <slot name="iconInactive"></slot>
+          <slot name="iconInactive" />
         </template>
       </tree-row>
     </ul>
@@ -39,11 +39,11 @@
 </template>
 
 <script>
-import { ref, watch, reactive } from 'vue'
-import TreeRow from './TreeRow.vue'
-import initData from '../composables/initData'
-import useSearch from '../composables/useSearch'
-import { setNodeById, getNodeById, updateNodeById, updateNodes } from '../utils'
+import { ref, watch, reactive } from 'vue';
+import TreeRow from './TreeRow.vue';
+import initData from '../composables/initData';
+import useSearch from '../composables/useSearch';
+import { setNodeById, getNodeById, updateNodeById, updateNodes } from '../utils';
 
 export default {
   name: 'Tree',
@@ -61,7 +61,7 @@ export default {
         return {
           nodes: 'nodes',
           label: 'label',
-        }
+        };
       },
     },
     indentSize: {
@@ -103,56 +103,56 @@ export default {
   },
   emits: ['nodeExpanded', 'checkboxToggle', 'update'],
   setup(props, { emit }) {
-    const { search } = useSearch()
-    const state = reactive({ data: initData(props.nodes)})
-    const reactiveExpandRowByDefault = ref(props.expandRowByDefault)
+    const { search } = useSearch();
+    const state = reactive({ data: initData(props.nodes) });
+    const reactiveExpandRowByDefault = ref(props.expandRowByDefault);
 
     const setNode = (id, node) => {
-      state.data.value = setNodeById(state.data, id, node)
-    }
+      state.data.value = setNodeById(state.data, id, node);
+    };
 
-    const getNode = (id) => {
-      return getNodeById(state.data, id)
-    }
+    const getNode = id => {
+      return getNodeById(state.data, id);
+    };
 
     const updateNode = (id, data) => {
-      state.data = updateNodes(updateNodeById(state.data, id, data))
-    }
+      state.data = updateNodes(updateNodeById(state.data, id, data));
+    };
 
-    const toggleCheckbox = (id)  => {
+    const toggleCheckbox = id => {
       const { checked } = getNode(id);
       updateNode(id, { checked: !checked });
-    }
+    };
 
     watch(()=> state.data, ()=>{
-      emit('update', state.data)
-    })
+      emit('update', state.data);
+    });
 
     watch(() => props.searchText, () => {
-      let newData = state.data
+      let newData = state.data;
       if (props.searchText !== '') {
-        newData = search(props.nodes, props.searchText, props.props)
+        newData = search(props.nodes, props.searchText, props.props);
         if (props.expandAllRowsOnSearch) {
-          reactiveExpandRowByDefault.value = true
+          reactiveExpandRowByDefault.value = true;
         }
       } else {
-        newData = props.nodes
-        reactiveExpandRowByDefault.value = false
+        newData = props.nodes;
+        reactiveExpandRowByDefault.value = false;
       }
-      state.data = updateNodes(newData)
-    })
+      state.data = updateNodes(newData);
+    });
 
     const onNodeExpanded = (node, state) => {
-      emit('nodeExpanded', node, state)
-    }
+      emit('nodeExpanded', node, state);
+    };
 
-    const onCheckboxToggle = (context) => {
-      emit('checkboxToggle', context)
-    }
+    const onCheckboxToggle = context => {
+      emit('checkboxToggle', context);
+    };
 
     const onUpdate = () => {
-      emit('update', state.data)
-    }
+      emit('update', state.data);
+    };
 
     return {
       setNode,
@@ -163,10 +163,10 @@ export default {
       reactiveExpandRowByDefault,
       onCheckboxToggle,
       onUpdate,
-      toggleCheckbox
-    }
+      toggleCheckbox,
+    };
   },
-}
+};
 </script>
 
 <style lang="scss" scoped>

--- a/src/lib/components/TreeRow.vue
+++ b/src/lib/components/TreeRow.vue
@@ -26,10 +26,10 @@
         </template>
       </div>
       <slot
-        name="checkbox" 
+        :id="node.id"
+        name="checkbox"
         :checked="node.checked"
         :indeterminate="node.indeterminate"
-        :id="node.id"
       />
       <input
         v-if="useCheckbox"
@@ -38,7 +38,7 @@
         :checked="node.checked"
         :indeterminate="node.indeterminate"
         @click.stop="toggleCheckbox"
-      >
+      />
       <span class="tree-row-txt">
         {{ node.label }}
       </span>
@@ -78,21 +78,21 @@
         </template>
         <template #checkbox="{ checked, indeterminate, id }">
           <slot
-            name="checkbox" 
+            :id="id"
+            name="checkbox"
             :checked="checked"
             :indeterminate="indeterminate"
-            :id="id"
           />
-      </template>
+        </template>
       </tree-row>
     </ul>
   </li>
 </template>
 
 <script>
-import { nextTick, watch } from 'vue'
-import ArrowRight from './Icons/ArrowRight.vue'
-import ArrowDown from './Icons/ArrowDown.vue'
+import { nextTick, watch } from 'vue';
+import ArrowRight from './Icons/ArrowRight.vue';
+import ArrowDown from './Icons/ArrowDown.vue';
 
 export default {
   components: {
@@ -149,43 +149,43 @@ export default {
   setup(props, { emit }) {
     const toggleExpanded = node => {
       if (props.expandable) {
-        props.node.expanded = props.node.nodes ? !props.node.expanded : false
+        props.node.expanded = props.node.nodes ? !props.node.expanded : false;
         nextTick(() => {
-          emit('nodeExpanded', node, props.node.expanded)
-        })
+          emit('nodeExpanded', node, props.node.expanded);
+        });
       }
-    }
+    };
 
     watch(() => props.expandRowByDefault, newVal => {
       if (props.node.nodes) {
-        props.node.expanded = !props.expandable
+        props.node.expanded = !props.expandable;
       }
     }, {
       immediate: true,
-    })
+    });
 
     // redirect the event toward the Tree component
     const onNodeExpanded = (node, state) => {
-      emit('nodeExpanded', node, state)
-    }
+      emit('nodeExpanded', node, state);
+    };
 
     const toggleCheckbox = () => {
       const { node, updateNode } = props;
       updateNode(node.id, { checked: !node.checked });
-    }
+    };
 
     const onCheckboxToggle = (context, event) => {
-      emit('checkboxToggle', context, event)
-    }
+      emit('checkboxToggle', context, event);
+    };
 
     return {
       toggleExpanded,
       onNodeExpanded,
       toggleCheckbox,
       onCheckboxToggle,
-    }
+    };
   },
-}
+};
 </script>
 
 <style lang="scss">

--- a/src/lib/components/TreeRow.vue
+++ b/src/lib/components/TreeRow.vue
@@ -42,6 +42,13 @@
       <span class="tree-row-txt">
         {{ node.label }}
       </span>
+      <template v-if="node && useRowDelete">
+        <div class="close-icon" @click.stop="removedRow(node)">
+          <slot name="closeIcon">
+            <delete-icon />
+          </slot>
+        </div>
+      </template>
     </div>
     <ul
       v-if="node.expanded"
@@ -55,6 +62,7 @@
         :node="child"
         :use-checkbox="useCheckbox"
         :use-icon="useIcon"
+        :use-row-delete="useRowDelete"
         :gap="gap"
         :expand-row-by-default="expandRowByDefault"
         :indent-size="indentSize"
@@ -63,6 +71,7 @@
         :get-node="getNode"
         :update-node="updateNode"
         :expandable="expandable"
+        @delete-row="removedRow"
         @node-expanded="onNodeExpanded"
         @checkbox-toggle="onCheckboxToggle"
       >
@@ -74,6 +83,11 @@
         <template #iconInactive>
           <slot name="iconInactive">
             <arrow-down />
+          </slot>
+        </template>
+        <template #closeIcon>
+          <slot name="closeIcon">
+            <delete-icon />
           </slot>
         </template>
         <template #checkbox="{ checked, indeterminate, id }">
@@ -93,11 +107,13 @@
 import { nextTick, watch } from 'vue';
 import ArrowRight from './Icons/ArrowRight.vue';
 import ArrowDown from './Icons/ArrowDown.vue';
+import DeleteIcon from './Icons/DeleteIcon.vue';
 
 export default {
   components: {
     ArrowRight,
     ArrowDown,
+    DeleteIcon,
   },
   props: {
     node: {
@@ -136,6 +152,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    useRowDelete:{
+      type: Boolean,
+      default: false,
+    },
     rowHoverBackground: {
       type: String,
       default: '#e0e0e0',
@@ -145,7 +165,7 @@ export default {
       default: true,
     },
   },
-  emits: ['nodeExpanded', 'checkboxToggle'],
+  emits: ['nodeExpanded', 'checkboxToggle', 'deleteRow'],
   setup(props, { emit }) {
     const toggleExpanded = node => {
       if (props.expandable) {
@@ -178,11 +198,16 @@ export default {
       emit('checkboxToggle', context, event);
     };
 
+    const removedRow = node => {
+      emit('deleteRow', node);
+    };
+
     return {
       toggleExpanded,
       onNodeExpanded,
       toggleCheckbox,
       onCheckboxToggle,
+      removedRow,
     };
   },
 };
@@ -199,6 +224,8 @@ export default {
   transform-style: preserve-3d;
 
   &-item {
+    display: flex;
+    align-items: center;
     position: relative;
     padding: 5px 10px;
 
@@ -215,11 +242,28 @@ export default {
       z-index: -1;
     }
 
+    .close-icon {
+      color: red;
+      opacity: 0;
+
+      > * {
+        display: flex;
+        width: 16px;
+        height: 16px;
+      }
+    }
+
     &-icon-wrapper {
       width: 15px;
       display: inline-flex;
       align-items: center;
       justify-content: center;
+    }
+  }
+
+  &-item:hover {
+    .close-icon {
+      opacity: 1;
     }
   }
 

--- a/src/lib/components/TreeRow.vue
+++ b/src/lib/components/TreeRow.vue
@@ -245,12 +245,10 @@ export default {
     .close-icon {
       color: red;
       opacity: 0;
-
-      > * {
-        display: flex;
-        width: 16px;
-        height: 16px;
-      }
+      display: flex;
+      align-items: center;
+      width: 16px;
+      height: 16px;
     }
 
     &-icon-wrapper {

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -1,6 +1,6 @@
-import getNodeById from "./getNodeById";
-import setNodeById from "./setNodeById";
-import updateNodeById from "./updateNodeById";
-import updateNodes from "./updateNodes";
+import getNodeById from './getNodeById';
+import setNodeById from './setNodeById';
+import updateNodeById from './updateNodeById';
+import updateNodes from './updateNodes';
 
 export { getNodeById, setNodeById, updateNodeById, updateNodes };

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -2,5 +2,6 @@ import getNodeById from './getNodeById';
 import setNodeById from './setNodeById';
 import updateNodeById from './updateNodeById';
 import updateNodes from './updateNodes';
+import removeNodeById from './removeNodeById';
 
-export { getNodeById, setNodeById, updateNodeById, updateNodes };
+export { getNodeById, setNodeById, updateNodeById, updateNodes, removeNodeById };

--- a/src/lib/utils/removeNodeById.js
+++ b/src/lib/utils/removeNodeById.js
@@ -16,3 +16,5 @@ function removeNodeById(nodes, id) {
 
   return newNodes;
 }
+
+export default removeNodeById;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add item delete feature for vue3-tree


* **What is the new behavior (if this is a feature change)?**
Add item delete feature


* **Other information**:
The user can optionally enable this feature. If we want to enable the delete feature in our sample data in the `App.vue` file, we just need to add the `use-row-delete` prop to the tree component.
Example:
```vue
<template>
  <Tree
    :nodes="data"
    :use-checkbox="true"
    use-row-delete
  />
</template>

<script>
import { ref } from 'vue';
import Tree from './lib/index';

export default {
  components: {
    Tree,
  },
  setup() {
    const data = ref([
      {
        id: 1,
       .
       .
       .
    ]);

    return {
      data,
    };
  },
};
</script>
```
Before deleting:
![image](https://user-images.githubusercontent.com/32914083/142894655-caad498b-d2d7-4bb2-8e20-fb05230c7377.png)

After deleting:
![image](https://user-images.githubusercontent.com/32914083/142894963-b4f316e4-e208-433a-a951-5abe2227e73d.png)
