### PR TITLE
Add feature to show number of children for parent

### DIFF
--- a/src/lib/components/Tree.vue
+++ b/src/lib/components/Tree.vue
@@ -9,6 +9,7 @@
         :use-checkbox="useCheckbox"
         :use-icon="useIcon"
         :use-row-delete="useRowDelete"
+        :show-child-count="showChildCount"
         :indent-size="indentSize"
         :gap="gap"
         :expand-row-by-default="reactiveExpandRowByDefault"
@@ -98,6 +99,10 @@ export default {
       default: true,
     },
     useRowDelete:{
+      type: Boolean,
+      default: false,
+    },
+    showChildCount: {
       type: Boolean,
       default: false,
     },

--- a/src/lib/components/TreeRow.vue
+++ b/src/lib/components/TreeRow.vue
@@ -42,6 +42,9 @@
       <span class="tree-row-txt">
         {{ node.label }}
       </span>
+      <template v-if="node.nodes && showChildCount">
+        <span class="child-count">{{ node.nodes.length }}</span>
+      </template>
       <template v-if="node && useRowDelete">
         <div class="close-icon" @click.stop="removedRow(node)">
           <slot name="closeIcon">
@@ -63,6 +66,7 @@
         :use-checkbox="useCheckbox"
         :use-icon="useIcon"
         :use-row-delete="useRowDelete"
+        :show-child-count="showChildCount"
         :gap="gap"
         :expand-row-by-default="expandRowByDefault"
         :indent-size="indentSize"
@@ -156,6 +160,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    showChildCount: {
+      type: Boolean,
+      default: false,
+    },
     rowHoverBackground: {
       type: String,
       default: '#e0e0e0',
@@ -240,6 +248,11 @@ export default {
       width: 200vw;
       margin-left: calc(100% - 100vw);
       z-index: -1;
+    }
+
+    .child-count {
+      color: gray;
+      margin-left: 6px;
     }
 
     .close-icon {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add feature to show number of children for parent

* **What is the new behavior (if this is a feature change)?**
Show number of children for parent

* **Other information**:
The user can optionally enable this feature. If we want to know how many child items the parent item belongs to in our sample data in the `App.vue` file, it is sufficient to add the `show-child-count` prop to the tree component.

Example:
```vue
<template>
  <Tree
    :nodes="data"
    :use-checkbox="true"
    show-child-count
  />
</template>

<script>
import { ref } from 'vue';
import Tree from './lib/index';

export default {
  components: {
    Tree,
  },
  setup() {
    const data = ref([
      {
        id: 1,
       .
       .
       .
    ]);

    return {
      data,
    };
  },
};
</script>
```

Screenshot:
![image](https://user-images.githubusercontent.com/32914083/143051865-237228c4-b43b-4bfd-baaf-4f2ddf6b093f.png)
