### PR TITLE
Add left margin to checkbox label

### DIFF
--- a/src/lib/components/TreeRow.vue
+++ b/src/lib/components/TreeRow.vue
@@ -300,6 +300,7 @@ export default {
 
   &-txt {
     user-select: none;
+    margin-rigth:3px;
   }
 }
 </style>

--- a/src/lib/components/TreeRow.vue
+++ b/src/lib/components/TreeRow.vue
@@ -300,7 +300,7 @@ export default {
 
   &-txt {
     user-select: none;
-    margin-rigth:3px;
+    margin-left:3px;
   }
 }
 </style>


### PR DESCRIPTION
Description:
I noticed that the checkbox label is visually too close to the checkbox, so I added a left margin of 3px to improve the spacing.

Changes Made:
In the CSS for the tree component, I added a margin-left: 3px; property to the li.tree-row > div.tree-row-item > span.tree-row-txt selector.

Testing:
I tested this change locally on different browsers and screen sizes to make sure it doesn't cause any layout issues.

