### PR TITLE
Toggling checkbox of parent does not toggle checkbox of all children (fix child node status)

### DIFF
--- a/src/lib/utils/updateChildNodeStatus.js
+++ b/src/lib/utils/updateChildNodeStatus.js
@@ -5,19 +5,10 @@ function updateChildNodeStatus(node, checkedStatus) {
 
   if (node && Array.isArray(node.nodes)) {
     node.nodes = node.nodes.map(item => {
-      const currentNode = {
-        ...item,
-        checked,
-      };
-
-      if (item.nodes) {
-        currentNode.nodes.forEach(childNode => updateChildNodeStatus(childNode, checked));
-      } else {
-        delete currentNode.nodes;
-      }
-
-      return currentNode;
+      return updateChildNodeStatus(item, checked)
     });
+  } else {
+    delete node.nodes;
   }
 
   return node;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fixing updateChildNodeStatus


* **What is the current behavior?** (You can also link to an open issue here)
the checkbox in the parent node **does not** update the child node that is located directly under the parent node.

* **What is the new behavior (if this is a feature change)?**
the checkbox in the parent node **will** update the child node that is located directly under the parent node.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

closes: https://github.com/wopehq/vue3-tree/issues/115
